### PR TITLE
command->shell to include apps under Utilities

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,8 @@
 
 # Command uses `basename` to return only filenames (excludes paths)
 # Source: http://superuser.com/a/620591
-# TODO: Would this find Terminal.app in /Applications/Utilities?
 - name: Get list of .app files in /Applications
-  command: find . -depth 1 -name "*.app" -exec basename {} \;
+  shell: find . -name '*.app' -maxdepth 2 | sed 's/^\.\///'
   args:
     chdir: /Applications
   register: installed_apps


### PR DESCRIPTION
As your original `TODO` suggests, currently, this role won't find anything under `/Applications/Utilities`, so something like Terminal can't get automatically added to the dock.

Changing the find command to go a level deeper is straightforward, but then the `basename` command will strip off the subdirectory (`Utilities/`). There might still be a way to do this as a one-liner using only arguments to `find`, but I think it's much easier to just pipe the output to sed to strip off the prefix `./`. Unfortunately, to use a shell pipe, you need to change the module used from `command` to `shell`. That could break cross-platform compatibility, but this role is only intended for OSX, so I didn't see that as an issue.

This pull request:
 * changes the ansible module from `command` to `shell`
 * adds the `-maxdepth 2` option to find to retrieve everything in `/Applications` and `/Applications/Utilities`
 * eliminates the use of `basename` in favor of a `sed` command that strips off the `./`
 * Closes out the `TODO`

I've tested this locally and can confirm that I can now add `Utilities/Terminal.app` to my `dock_items` var and it works correctly (along with all the other normal apps just sitting in `/Applications`).